### PR TITLE
Alt+Shift shows the hidden menu and blocks input

### DIFF
--- a/app/lib/menus.js
+++ b/app/lib/menus.js
@@ -45,6 +45,10 @@ class Menus {
 
     window.setMenu(new Menu.buildFromTemplate([
       {
+        // workaround for alt+shift showing the hidden menu and blocking input
+        label: ''
+      },
+      {
         label: 'File',
         submenu: appMenu
       },


### PR DESCRIPTION
Workaround: Adding hidden menu at the beginning causes the menu to flicker
but it will not stay and block keyboard input.