### PR TITLE
Update User-Agent to Chrome 60

### DIFF
--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -46,7 +46,7 @@ app.on('ready', () => {
     });
   });
 
-  window.webContents.setUserAgent('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36');
+  window.webContents.setUserAgent('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.90 Safari/537.36');
   window.loadURL('https://teams.microsoft.com/');
 
   if (process.env.WEB_DEBUG) {

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Microsoft Teams for Linux",
   "main": "lib/index.js",
   "author": "Ivelin Velkov <ivelin.velkov@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-for-linux",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Unofficial client for Microsoft Teams for Linux",
   "homepage": "https://github.com/ivelkov/teams-for-linux",
   "keywords": [


### PR DESCRIPTION
As reported in #22, it appears Microsoft has stopped supporting Chrome versions earlier than v60.  Updating the user agent string seems to resolve the issue.

The ~/.config/teams-for-linux/ directory may need to be removed to clear cache and fix the error.