### PR TITLE
fix #26 changed StartupWMClass to teams-for-linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
       "desktop": {
         "Name": "Microsoft Teams for Linux",
         "Comment": "Unofficial client for Microsoft Teams for Linux",
-        "StartupWMClass": "teams"
+        "StartupWMClass": "teams-for-linux"
       },
       "target": [
         "tar.gz",


### PR DESCRIPTION
Because of the wrong StartupWMClass the application icon was wrong. Fixed by changing it to teams-for-linux